### PR TITLE
Avoid CSS hijacking

### DIFF
--- a/generate-styles.js
+++ b/generate-styles.js
@@ -1,13 +1,12 @@
 const fs = require('fs');
+const url = require('url');
 
 let rawdata = fs.readFileSync('names.json');
 let names = JSON.parse(rawdata);
 let output = "";
 
 names.forEach(function (item) {
-	var link = item.link.replace(/^(?:https?:\/\/)?(?:www\.)?/i, "");
-	link = link.split("?")[0];
-	ghUsername = link.split("github.com/")[1];
+	let ghUsername = url.parse(item.link).pathname?.slice(1)
 	if(ghUsername != undefined) {
 		if(ghUsername.length > 4 && ghUsername != "event") { //basic sanity check
 			output += `a[href*="${ghUsername.replace(/\/+$/, '')}"], `; //remove the trailing backslash


### PR DESCRIPTION
This is off the top of my head (edited on github without checking out repo locally), but I did a quick test on the current link that's breaking this:


<img width="704" alt="image" src="https://user-images.githubusercontent.com/166258/113058441-20f79200-917c-11eb-9a8c-ae9ef1c8ae25.png">


```
> url.parse("http://github.com/augustozanellato#\"]{}*{background-image:url(\"https://camo.githubusercontent.com/e97b5645ec8c0b8eb5386cc8452df5cdb92d0b7674ea8e4a2d75506aa3beca5b/68747470733a2f2f7374616c6c6d616e2e6f72672f7361696e7469676e75636975732e6a7067\")}/*").pathname?.slice(1)
'augustozanellato'
```