### PR TITLE
Improve GitHub username extraction

### DIFF
--- a/generate-styles.js
+++ b/generate-styles.js
@@ -5,16 +5,54 @@ let rawdata = fs.readFileSync('names.json');
 let names = JSON.parse(rawdata);
 let output = "";
 
+function linkToGithubUsername(rawLink) {
+	// if the link is a link to a GitHub user, return the username in
+	// URI-escaped form. otherwise, return `null`.
+
+	if (!(typeof rawLink === 'string' || rawLink instanceof String)) {
+		// the link is not a string
+		return null;
+	}
+
+	// truncate to avoid maliciously excessively long URLs
+	let link = url.parse(rawLink.slice(0, 100));
+
+	if (!(link.protocol == 'http:' || link.protocol == 'https:')) {
+		// link is not HTTP(S)
+		return null;
+	}
+	if (!(link.host == 'github.com' || link.host == 'www.github.com')) {
+		// link is not github.com
+		return null;
+	}
+
+	// we `.slice(1)` to remove the leading backslash
+	let pathParts = link.pathname.slice(1).split('/');
+	if (pathParts.length != 1) {
+		// link has the wrong number of path parts
+		return null;
+	}
+
+	// url.parse automatically performs URI escaping
+	return pathParts[0];
+}
+
+function isGithubUsernameReasonable(username) {
+	// collection of sanity checks on github usernames.
+	// returns `true` if passes all sanity checks.
+
+	if (username.length <= 4) {
+		// username is too short
+		return false;
+	}
+
+	return true;
+}
+
 names.forEach(function (item) {
-	if(item.link.includes("github.com")) {
-	   	ghUsername = url.parse(item.link).pathname.slice(1);
-		if(ghUsername != undefined) {
-			if(ghUsername.length > 4) { //basic sanity check
-				output += `a[href$="${ghUsername}"], `; //remove the trailing backslash
-			} else {
-				return;
-			}
-		}
+	let ghUsername = linkToGithubUsername(item);
+	if (ghUsername !== null && isGithubUsernameReasonable(ghUsername)) {
+		output += `a[href$="${ghUsername}"], `;
 	}
 });
 


### PR DESCRIPTION
Following [my comment](https://github.com/sticks-stuff/highlight-RMS-supporters/pull/49#issuecomment-810701369) on #49. 

# Commit Message

```
Improve github username extraction.

This commit creates a function for detecting whether a URL is a link
to a GitHub user, and returning the GitHub user's username. It takes
advantage of the built-in `url.parse` function to a greater degree than
the code it replaces, so as to reduce bugs and edge cases. The checks
are largely based on work in #49.

This commit also factors out the github username sanity checks is a
similar way.
```

# Testing

The workflow appears to work on my branch [[link]](https://github.com/gretchenfrage/highlight-RMS-supporters/runs/2234141206?check_suite_focus=true). However, I have done some minor whitespace cleanup since that workflow ran. 

Also you can use `node` to manually test the function, which I did to a certain degree.
