### PR TITLE
Create highlight-rms-supporters.user.css

### DIFF
--- a/highlight-rms-supporters.user.css
+++ b/highlight-rms-supporters.user.css
@@ -1,9 +1,9 @@
-/* ==UserScript==
+/* ==UserStyle==
 @name            Highlight RMS supporters
 @description     Highlights those who have signed the RMS Support letter
 @match           https://github.com/*
 @author          stick
 @version         1.3
 @homepageURL     https://github.com/sticks-stuff/highlight-RMS-supporters
-==/UserScript== */
+==/UserStyle== */
 @import "https://sticks-stuff.github.io/highlight-RMS-supporters/styles.css";

--- a/highlight-rms-supporters.user.css
+++ b/highlight-rms-supporters.user.css
@@ -1,0 +1,9 @@
+/* ==UserScript==
+@name            Highlight RMS supporters
+@description     Highlights those who have signed the RMS Support letter
+@match           https://github.com/*
+@author          stick
+@version         1.3
+@homepageURL     https://github.com/sticks-stuff/highlight-RMS-supporters
+==/UserScript== */
+@import "https://sticks-stuff.github.io/highlight-RMS-supporters/styles.css";

--- a/highlight-rms-supporters.user.css
+++ b/highlight-rms-supporters.user.css
@@ -5,5 +5,6 @@
 @author          stick
 @version         1.3.0
 @homepageURL     https://github.com/sticks-stuff/highlight-RMS-supporters
+@namespace       https://github.com/sticks-stuff/highlight-RMS-supporters
 ==/UserStyle== */
 @import "https://sticks-stuff.github.io/highlight-RMS-supporters/styles.css";

--- a/highlight-rms-supporters.user.css
+++ b/highlight-rms-supporters.user.css
@@ -3,7 +3,7 @@
 @description     Highlights those who have signed the RMS Support letter
 @match           https://github.com/*
 @author          stick
-@version         1.3
+@version         1.3.0
 @homepageURL     https://github.com/sticks-stuff/highlight-RMS-supporters
 ==/UserStyle== */
 @import "https://sticks-stuff.github.io/highlight-RMS-supporters/styles.css";


### PR DESCRIPTION
Straightforwardly, add a UserStyle to be used by an extension like Stylus.

Fixes #5, but also fixes #46 since we don't load the style from JS anymore.